### PR TITLE
Fix typo in router error message

### DIFF
--- a/pricer/internal/router/router.go
+++ b/pricer/internal/router/router.go
@@ -19,7 +19,7 @@ func NewRouter(cfg *auth.AuthConfig, httpClient *http.Client) (http.Handler, err
 	qsrv := service.NewQueueService()
 	psrv, err := service.NewPricingService(cfg, httpClient, repo)
 	if err != nil {
-		return nil, fmt.Errorf("falied to initialize router: %w", err)
+		return nil, fmt.Errorf("failed to initialize router: %w", err)
 	}
 
 	pricingHandler := handler.NewPricingHandler(psrv)


### PR DESCRIPTION
## Summary
- fix misspelled word in router error message

## Testing
- `go test ./...` *(fails: unable to download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef164810833284e8afeb6ec012b6