### PR TITLE
Update Go version to 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # VENDIQ2
+
+## Requirements
+
+This project requires [Go](https://go.dev/dl/) **1.22** or newer.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.22-alpine
 
 WORKDIR /app
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/chiyonn/vendiq2/api
 
-go 1.23.7
+go 1.22
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1

--- a/pricer/Dockerfile
+++ b/pricer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.22-alpine
 
 WORKDIR /app
 

--- a/pricer/go.mod
+++ b/pricer/go.mod
@@ -1,6 +1,6 @@
 module github.com/chiyonn/vendiq2/pricer
 
-go 1.23.9
+go 1.22
 
 require (
 	github.com/chiyonn/spapi v0.0.0-20250531042911-029b4cf5be8b


### PR DESCRIPTION
## Summary
- use Go 1.22 for api and pricer modules
- update corresponding Dockerfiles to golang:1.22-alpine
- document required Go version in README

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840f03c71e083329fbad2ee63d301b0