### PR TITLE
Add researcher service

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project requires [Go](https://go.dev/dl/) **1.23** or newer.
 
 - **api** – simple REST API exposing pricing data from MySQL.
 - **pricer** – main service implementing price adjustment logic, RabbitMQ worker and HTTP endpoints.
+- **researcher** – minimal service exposing a `/health` endpoint.
 - **webui** – Vite + React front‑end to view and edit pricing and queue jobs.
 - **compose.yaml** – Docker Compose configuration for local development (frontend, pricer and RabbitMQ).
 - **Makefile** – helper targets to build and run the Docker environment.

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,6 +35,21 @@ services:
       - LWA_CLIENT_SECRET
     depends_on:
       - rabbitmq
+
+  researcher:
+    container_name: dev-vendiq2-researcher
+    build:
+      context: ./researcher
+      dockerfile: Dockerfile
+    ports:
+      - "8082:8080"
+    command: air
+    volumes:
+      - ./researcher:/app
+    environment:
+      - APP_ENV=development
+    depends_on:
+      - rabbitmq
  
   rabbitmq:
     container_name: dev-vendiq2-rabbit

--- a/researcher/.air.toml
+++ b/researcher/.air.toml
@@ -1,0 +1,53 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ./cmd/server"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true
+

--- a/researcher/Dockerfile
+++ b/researcher/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.23-alpine
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN go install github.com/air-verse/air@latest
+
+EXPOSE 8080
+
+CMD ["./main"]
+
+

--- a/researcher/cmd/server/main.go
+++ b/researcher/cmd/server/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+    "log"
+    "net/http"
+
+    "github.com/chiyonn/vendiq2/researcher/internal/router"
+)
+
+func main() {
+    r := router.NewRouter()
+
+    log.Println("Starting server on :8080")
+    if err := http.ListenAndServe(":8080", r); err != nil {
+        log.Fatalf("server error: %v", err)
+    }
+}
+

--- a/researcher/go.mod
+++ b/researcher/go.mod
@@ -1,0 +1,5 @@
+module github.com/chiyonn/vendiq2/researcher
+
+go 1.23.9
+
+require github.com/go-chi/chi/v5 v5.2.1

--- a/researcher/go.sum
+++ b/researcher/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/researcher/internal/handler/health.go
+++ b/researcher/internal/handler/health.go
@@ -1,0 +1,9 @@
+package handler
+
+import "net/http"
+
+func Health(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+    w.Write([]byte(`{"status":"ok"}`))
+}
+

--- a/researcher/internal/router/router.go
+++ b/researcher/internal/router/router.go
@@ -1,0 +1,15 @@
+package router
+
+import (
+    "net/http"
+
+    "github.com/chiyonn/vendiq2/researcher/internal/handler"
+    "github.com/go-chi/chi/v5"
+)
+
+func NewRouter() http.Handler {
+    r := chi.NewRouter()
+    r.Get("/health", handler.Health)
+    return r
+}
+


### PR DESCRIPTION
## Summary
- implement new `researcher` Go service with a `/health` endpoint
- allow launching the service via Docker Compose
- document the `researcher` directory

## Testing
- `make build` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684103ece5c88332b0af99f36721ecf2