### PR TITLE
Add Research page and health indicator

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import PricingPage from "@/pages/PricingPage";
 import PricingQueuesPage from "@/pages/PricingQueuesPage";
+import ResearchPage from "@/pages/ResearchPage";
 import MainLayout from "@/layouts/MainLayout";
 import "./App.css";
 
@@ -11,6 +12,7 @@ function App() {
                 <Route path="/" element={<Navigate to="/pricings" replace />} />
                 <Route path="/pricings" element={<PricingPage />} />
                 <Route path="/pricings/queues" element={<PricingQueuesPage />} />
+                <Route path="/research" element={<ResearchPage />} />
             </Route>
         </Routes>
     );

--- a/webui/src/components/global/PageNav/index.tsx
+++ b/webui/src/components/global/PageNav/index.tsx
@@ -5,11 +5,13 @@ import styles from './PageNav.module.css';
 type Service = {
     name: string;
     host: string;
+    link: string;
 };
 
 const PageNav = () => {
     const services: Service[] = [
-        { name: '価格設定', host: '/pricer' },
+        { name: '価格設定', host: '/pricer', link: '/pricings' },
+        { name: 'リサーチ', host: '/researcher', link: '/research' },
     ];
 
     const [statuses, setStatuses] = useState<Record<string, 'ok' | 'fail'>>({});
@@ -36,7 +38,7 @@ const PageNav = () => {
         <div className={styles.container}>
             {services.map((service) => (
                 <div className={styles.row} key={service.host}>
-                    <Link to="/pricings">{service.name}</Link>
+                    <Link to={service.link}>{service.name}</Link>
                     <p className={statuses[service.host] === 'ok' ? styles.green : styles.red}>
                         ●
                     </p>

--- a/webui/src/pages/ResearchPage/ResearchPage.module.css
+++ b/webui/src/pages/ResearchPage/ResearchPage.module.css
@@ -1,0 +1,3 @@
+.container {
+    padding: 1rem;
+}

--- a/webui/src/pages/ResearchPage/index.tsx
+++ b/webui/src/pages/ResearchPage/index.tsx
@@ -1,0 +1,9 @@
+import styles from './ResearchPage.module.css';
+
+const ResearchPage = () => {
+    return (
+        <div className={styles.container}></div>
+    );
+};
+
+export default ResearchPage;

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
                 changeOrigin: true,
                 rewrite: path => path.replace(/^\/pricer/, ''),
             },
+            '/researcher': {
+                target: 'http://researcher:8080',
+                changeOrigin: true,
+                rewrite: path => path.replace(/^\/researcher/, ''),
+            },
         },
     },
 })


### PR DESCRIPTION
## Summary
- link up Researcher API in the dev proxy
- show Research service status in PageNav
- add blank Research page and route

## Testing
- `yarn lint` *(fails: Unexpected any errors)*
- `make build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68410ba55d508332b2da49aa593eb50c