### PR TITLE
Update Go version references to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ VENDIQ2 is a set of small services for managing prices on Amazon. The repository
 
 ## Requirements
 
-This project requires [Go](https://go.dev/dl/) **1.23** or newer.
+This project requires [Go](https://go.dev/dl/) **1.24** or newer.
 
 ## Directory overview
 

--- a/pricer/Dockerfile
+++ b/pricer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /app
 

--- a/pricer/go.mod
+++ b/pricer/go.mod
@@ -1,6 +1,6 @@
 module github.com/chiyonn/vendiq2/pricer
 
-go 1.23.9
+go 1.24
 
 require (
 	github.com/chiyonn/spapi v0.0.0-20250531042911-029b4cf5be8b

--- a/researcher/Dockerfile
+++ b/researcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /app
 

--- a/researcher/go.mod
+++ b/researcher/go.mod
@@ -1,5 +1,5 @@
 module github.com/chiyonn/vendiq2/researcher
 
-go 1.23.9
+go 1.24
 
 require github.com/go-chi/chi/v5 v5.2.1


### PR DESCRIPTION
## Summary
- bump Go version requirement in README
- update Go version in go.mod for pricer and researcher
- use Go 1.24 images in Dockerfiles

## Testing
- `go test ./...` in `pricer` *(fails: cannot use mock types as inventory.API)*
- `make build` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68410e62b03c83328dd636f786150227