### PR TITLE
Add logging middleware to pricer and researcher

### DIFF
--- a/pricer/internal/router/middleware.go
+++ b/pricer/internal/router/middleware.go
@@ -1,0 +1,14 @@
+package router
+
+import (
+	"log"
+	"net/http"
+)
+
+// LoggingMiddleware logs the HTTP method and request path for each incoming request.
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pricer/internal/router/router.go
+++ b/pricer/internal/router/router.go
@@ -14,6 +14,7 @@ import (
 
 func NewRouter(cfg *auth.AuthConfig, httpClient *http.Client) (http.Handler, error) {
 	r := chi.NewRouter()
+	r.Use(LoggingMiddleware)
 	database := db.GetDB()
 	repo := repository.NewPricingRepository(database)
 	qsrv := service.NewQueueService()

--- a/researcher/internal/router/middleware.go
+++ b/researcher/internal/router/middleware.go
@@ -1,0 +1,14 @@
+package router
+
+import (
+	"log"
+	"net/http"
+)
+
+// LoggingMiddleware logs the HTTP method and request path for each request.
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/researcher/internal/router/router.go
+++ b/researcher/internal/router/router.go
@@ -1,15 +1,15 @@
 package router
 
 import (
-    "net/http"
+	"net/http"
 
-    "github.com/chiyonn/vendiq2/researcher/internal/handler"
-    "github.com/go-chi/chi/v5"
+	"github.com/chiyonn/vendiq2/researcher/internal/handler"
+	"github.com/go-chi/chi/v5"
 )
 
 func NewRouter() http.Handler {
-    r := chi.NewRouter()
-    r.Get("/health", handler.Health)
-    return r
+	r := chi.NewRouter()
+	r.Use(LoggingMiddleware)
+	r.Get("/health", handler.Health)
+	return r
 }
-


### PR DESCRIPTION
## Summary
- log every request to pricer and researcher services
- wire middleware into both routers

## Testing
- `go test ./...` in `pricer` *(fails: cannot use filteringMockInventoryAPI as *inventory.InventoryAPI)*
- `go test ./...` in `researcher`

------
https://chatgpt.com/codex/tasks/task_e_6841162ebcc88332b94f2dbf83ddc918